### PR TITLE
Fix build with gcc 13.1.1

### DIFF
--- a/src/libappimage/utils/hashlib.h
+++ b/src/libappimage/utils/hashlib.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // system
+#include <cstdint>
 #include <istream>
 #include <vector>
 


### PR DESCRIPTION
Hello, with the update of GCC to v13.1.1 `<cstdint>` need to be added otherwise the build fail

i.e.

```
[ 81%] Linking C static library libappimage_shared.a
[ 81%] Built target libappimage_shared
In file included from /home/fabio/Dev/Github/PKGBUILD-AUR_fix/n/libappimage/src/libappimage-1.0.4-5/src/libappimage/utils/hashlib.cpp:9:
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/n/libappimage/src/libappimage-1.0.4-5/src/libappimage/utils/hashlib.h:19:25: error: 'uint8_t' was not declared in this scope
   19 |             std::vector<uint8_t> md5(std::istream& data);
      |                         ^~~~~~~
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/n/libappimage/src/libappimage-1.0.4-5/src/libappimage/utils/hashlib.h:1:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | #pragma once
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/n/libappimage/src/libappimage-1.0.4-5/src/libappimage/utils/hashlib.h:19:32: error: template argument 1 is invalid
   19 |             std::vector<uint8_t> md5(std::istream& data);
      |                                ^
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/n/libappimage/src/libappimage-1.0.4-5/src/libappimage/utils/hashlib.h:19:32: error: template argument 2 is invalid
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/n/libappimage/src/libappimage-1.0.4-5/src/libappimage/utils/hashlib.h:26:25: error: 'uint8_t' was not declared in this scope
   26 |             std::vector<uint8_t> md5(const std::string& data);
      |                         ^~~~~~~
```
