### PR TITLE
use asprintf to allocate glob_pattern in appimage_registered_desktop_file_path()

### DIFF
--- a/src/libappimage/libappimage.c
+++ b/src/libappimage/libappimage.c
@@ -26,6 +26,9 @@
 
 #ident "AppImage by Simon Peter, http://appimage.org/"
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -65,9 +68,8 @@ char* appimage_registered_desktop_file_path(const char* path, char* md5, bool ve
 
     char* data_home = xdg_data_home();
 
-    // TODO: calculate this value exactly
-    char* glob_pattern = malloc(PATH_MAX);
-    sprintf(glob_pattern, "%s/applications/appimagekit_%s-*.desktop", data_home, md5);
+    char* glob_pattern = NULL;
+    asprintf(&glob_pattern, "%s/applications/appimagekit_%s-*.desktop", data_home, md5);
 
     glob(glob_pattern, 0, NULL, &pglob);
 


### PR DESCRIPTION
By the way, I see several allocated strings that aren't freed.  However explicitly freeing them creates double free errors in the tests, so not freeing them is the right thing to do here?