### PR TITLE
Fix compilation errors

### DIFF
--- a/src/libappimage/libappimage.c
+++ b/src/libappimage/libappimage.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <dirent.h>
+#include <limits.h>
 
 #include "xdg-basedir.h"
 

--- a/src/libappimage/utils/IconHandleCairoRsvg.cpp
+++ b/src/libappimage/utils/IconHandleCairoRsvg.cpp
@@ -1,6 +1,7 @@
 // libraries
 #include <glib-object.h>
 #include <fstream>
+#include <cstring>
 
 // local
 #include "IconHandle.h"

--- a/src/libappimage/utils/light_elf.h
+++ b/src/libappimage/utils/light_elf.h
@@ -26,7 +26,9 @@
 
 #include <inttypes.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef uint16_t Elf32_Half;
 typedef uint16_t Elf64_Half;
@@ -114,6 +116,8 @@ typedef struct elf32_note {
 #define EI_CLASS    4
 #define EI_DATA     5
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* elf.h */

--- a/src/libappimage_shared/light_elf.h
+++ b/src/libappimage_shared/light_elf.h
@@ -26,7 +26,9 @@
 
 #include <inttypes.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef uint16_t Elf32_Half;
 typedef uint16_t Elf64_Half;
@@ -114,6 +116,8 @@ typedef struct elf32_note {
 #define EI_CLASS    4
 #define EI_DATA     5
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* elf.h */


### PR DESCRIPTION
These two commits fix errors in compiling on:
- Ubuntu 14, which requires you to include cstring in order to use memcpy
- Alpine Linux, which when I attempt to compile the source code requires me to get rid of the __BEGIN_DECLS and __END_DECLS statements. These symbols also seem to be substandard according to the libtool manual:
https://www.gnu.org/software/libtool/manual/html_node/C-header-files.html (check 
footnotes)