### PR TITLE
fix crash when creating >2GB files on 32bit machine

### DIFF
--- a/src/libappimage_shared/elf.c
+++ b/src/libappimage_shared/elf.c
@@ -130,7 +130,7 @@ bool appimage_get_elf_section_offset_and_length(const char* fname, const char* s
 
 	// prevent map_size wrap around on 32bit platform
 	// we only need to read section header table, this should be big enough
-	if (file_size > UINT_MAX)
+	if (sizeof(long) == 4 && file_size > UINT_MAX)
 		map_size = INT_MAX;
 	else
 		map_size = (size_t)file_size;

--- a/src/libappimage_shared/elf.c
+++ b/src/libappimage_shared/elf.c
@@ -1,3 +1,4 @@
+#define _FILE_OFFSET_BITS 64
 #include <stdio.h>
 #include <stdint.h>
 #include <errno.h>

--- a/src/libappimage_shared/elf.c
+++ b/src/libappimage_shared/elf.c
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <memory.h>
 #include <sys/mman.h>
+#include <limits.h>
 
 #include "light_elf.h"
 #include "light_byteswap.h"
@@ -124,7 +125,12 @@ bool appimage_get_elf_section_offset_and_length(const char* fname, const char* s
 	uint8_t* data;
 	int i;
 	int fd = open(fname, O_RDONLY);
-	size_t map_size = (size_t) lseek(fd, 0, SEEK_END);
+	size_t map_size;
+	off_t file_size = lseek(fd, 0, SEEK_END);
+
+	// we only need to read section header table, this should be big enough
+	if (file_size > INT_MAX)
+		map_size = INT_MAX;
 
 	data = mmap(NULL, map_size, PROT_READ, MAP_SHARED, fd, 0);
 	close(fd);

--- a/src/libappimage_shared/elf.c
+++ b/src/libappimage_shared/elf.c
@@ -128,9 +128,12 @@ bool appimage_get_elf_section_offset_and_length(const char* fname, const char* s
 	size_t map_size;
 	off_t file_size = lseek(fd, 0, SEEK_END);
 
+	// prevent map_size wrap around on 32bit platform
 	// we only need to read section header table, this should be big enough
-	if (file_size > INT_MAX)
+	if (file_size > UINT_MAX)
 		map_size = INT_MAX;
+	else
+		map_size = (size_t)file_size;
 
 	data = mmap(NULL, map_size, PROT_READ, MAP_SHARED, fd, 0);
 	close(fd);


### PR DESCRIPTION
appimagetool will crash on appimage_get_elf_section_offset_and_length() when creating file larger than 2GB on 32bit machine, because in this line lssek() returns -1 and errno set to EOVERFLOW. map_size with value UINT_MAX(-1) is then passed to mmap().
```c
size_t map_size = (size_t) lseek(fd, 0, SEEK_END);
```
Adding "#define _FILE_OFFSET_BITS 64" will change off_t to 64bit, then we can get the correct file size from lseek. 

related issues:
#21 
> https://github.com/AppImage/AppImageKit/issues/1181