### PR TITLE
Bump minimum CMake version to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.6)
 
 project(libappimage)
 

--- a/cmake/reproducible_builds.cmake
+++ b/cmake/reproducible_builds.cmake
@@ -2,7 +2,7 @@
 # it will replace such paths with relative ones
 # see https://reproducible-builds.org/docs/build-path/ for more information
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.6)
 
 include(CheckCCompilerFlag)
 

--- a/cmake/scripts.cmake
+++ b/cmake/scripts.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 
 include(ExternalProject)
 

--- a/src/libappimage/CMakeLists.txt
+++ b/src/libappimage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 
 add_subdirectory(core)
 add_subdirectory(utils)


### PR DESCRIPTION
Fixes build with CMake `4.0.2` which shows error:

```console
CMake Error at PKGBUILD-AUR_fix/a/appimagelauncher-git/src/build/_deps/libappimage-src/src/libappimage/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```

Related to:

- AppImageCommunity/zsync2#82
- TheAssassin/AppImageLauncher#717