### PR TITLE
Fix build with libc++

### DIFF
--- a/src/libappimage/core/impl/PayloadIStream.h
+++ b/src/libappimage/core/impl/PayloadIStream.h
@@ -17,7 +17,7 @@ namespace appimage {
                 friend class TraversalType1;
                 friend class TraversalType2;
 
-                PayloadIStream() = default;
+                PayloadIStream() : std::istream(nullptr) {}
 
                 // Creating copies of this object is not allowed
                 PayloadIStream(PayloadIStream& other) = delete;

--- a/src/libappimage/core/impl/StreambufType1.cpp
+++ b/src/libappimage/core/impl/StreambufType1.cpp
@@ -27,7 +27,7 @@ StreambufType1::StreambufType1(archive* a, unsigned long size) : a(a), size(size
 StreambufType1::StreambufType1(StreambufType1&& other) noexcept
     : a(other.a), size(other.size), buffer(std::move(other.buffer)) {
     // Reset the three read area pointers
-    setg(other._M_in_beg, other._M_in_cur, other._M_in_end);
+    setg(other.eback(), other.gptr(), other.egptr());
 }
 
 StreambufType1& StreambufType1::operator=(StreambufType1&& other) noexcept {
@@ -36,7 +36,7 @@ StreambufType1& StreambufType1::operator=(StreambufType1&& other) noexcept {
     buffer = std::move(other.buffer);
 
     // Reset the three read area pointers
-    setg(other._M_in_beg, other._M_in_cur, other._M_in_end);
+    setg(other.eback(), other.gptr(), other.egptr());
 
     return *this;
 }

--- a/src/libappimage/core/impl/StreambufType2.cpp
+++ b/src/libappimage/core/impl/StreambufType2.cpp
@@ -26,7 +26,7 @@ StreambufType2::StreambufType2(StreambufType2&& other) noexcept
     : fs(other.fs), inode(other.inode), buffer(std::move(other.buffer)) {
 
     // Reset the three read area pointers
-    setg(other._M_in_beg, other._M_in_cur, other._M_in_end);
+    setg(other.eback(), other.gptr(), other.egptr());
 }
 
 StreambufType2& StreambufType2::operator=(StreambufType2&& other) noexcept {
@@ -35,7 +35,7 @@ StreambufType2& StreambufType2::operator=(StreambufType2&& other) noexcept {
     buffer = std::move(other.buffer);
 
     // Reset the three read area pointers
-    setg(other._M_in_beg, other._M_in_cur, other._M_in_end);
+    setg(other.eback(), other.gptr(), other.egptr());
     return *this;
 }
 


### PR DESCRIPTION
Two fixes:
 * std::istream does not have a default constructor in the C++ standard, so do what the libstdc++ constructor does
 * _M_in_beg and friends are not part of the C++ standard, use the actual functions that return those values in libstdc++